### PR TITLE
#30 Java 15 Upgrade

### DIFF
--- a/packages/web/docker-compose.yml
+++ b/packages/web/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
     morpher-api:
-        image: szgabsz91/morpher-api:1.3.0
+        image: szgabsz91/morpher-api:1.4.0
         container_name: morpher-api
         hostname: morpher-api
         ports:


### PR DESCRIPTION
- [ ] Use the Morpher API Docker image version 1.4.0 after the image is released